### PR TITLE
Add operation property to each request

### DIFF
--- a/src/routeBuilder.js
+++ b/src/routeBuilder.js
@@ -52,12 +52,21 @@ function getMiddleware(customMiddleware, operation, authorizers) {
   const preValidation = customMiddleware.filter(m => !m.validated).map(getAction).filter(util.isFunc)
   const postValidation = customMiddleware.filter(m => !!m.validated).map(getAction).filter(util.isFunc)
 
+  middleware.push(augmentRequest(operation))
+  
   if (authCheck) middleware.push(authCheck)
   if (preValidation.length) middleware.push.apply(middleware, preValidation)
   if (validationCheck) middleware.push(validationCheck)
   if (postValidation.length) middleware.push.apply(middleware, postValidation)
 
   return middleware
+}
+
+function augmentRequest(operation) {
+  return function augmentReq(req, res, next) {
+    req.operation = operation
+    return next()
+  }
 }
 
 /*

--- a/src/routeRegister.js
+++ b/src/routeRegister.js
@@ -18,7 +18,7 @@ function registerOperationRoutes(app, operations, options) {
   operations.forEach(operation => {
     const opPath = operation.fullPath.replace(/{([^}]+)}/g, ':$1')
     const stack = routeBuilder.buildHandlerStack(operation, authorizers, options)
-    assert.ok(stack.length > 0, `Missing operation handler for '${operation.id}'`)
+    assert.ok(stack.length > 1, `Missing operation handler for '${operation.id}'`)
     getHttpMethod(app, operation).apply(app, [ opPath ].concat(stack))
   })
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -41,7 +41,7 @@ describe('index', () => {
 
           verifyAppStackSize(app, 2)
 
-          verifyRoute(app, '/pets', [ 'validator', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ])
           verifyRoute(app, options.docsPath, [ 'handler' ])
         })
 
@@ -66,7 +66,7 @@ describe('index', () => {
           }
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'middleware', 'validator', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'middleware', 'validator', 'handler' ])
         })
 
         it('should support post validation middleware', () => {
@@ -79,7 +79,7 @@ describe('index', () => {
           }
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'validator', 'middleware', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'middleware', 'handler' ])
         })
 
         it('should support handler multi-middleware', () => {
@@ -95,7 +95,7 @@ describe('index', () => {
           }
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'middleware1', 'middleware2', 'validator', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'middleware1', 'middleware2', 'validator', 'handler' ])
         })
 
         it('should support pre and post validation middleware', () => {
@@ -111,14 +111,14 @@ describe('index', () => {
           }
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'middlewarePre', 'validator', 'middlewarePost', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'middlewarePre', 'validator', 'middlewarePost', 'handler' ])
         })
 
         it('should add auth middleware to secure routes', () => {
           const options2 = Object.assign({}, options, { api: secureApi })
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'authorize', 'validator', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'authorize', 'validator', 'handler' ])
         })
 
         it('should add auth middleware before other route middleware', () => {
@@ -131,7 +131,7 @@ describe('index', () => {
           }
 
           addHandlers(app, options2)
-          verifyRoute(app, '/pets', [ 'authorize', 'middleware', 'validator', 'handler' ])
+          verifyRoute(app, '/pets', [ 'augmentReq', 'authorize', 'middleware', 'validator', 'handler' ])
         })
 
         it('should support registering multiple Swagger api specs', () => {
@@ -143,10 +143,10 @@ describe('index', () => {
 
           verifyAppStackSize(app, 4)
 
-          verifyRoute(app, '/pets', [ 'validator', 'handler' ], api.basePath)
+          verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ], api.basePath)
           verifyRoute(app, options.docsPath, [ 'handler' ], api.basePath)
 
-          verifyRoute(app, '/pets', [ 'validator', 'handler' ], api2.basePath)
+          verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ], api2.basePath)
           verifyRoute(app, options.docsPath, [ 'handler' ], api2.basePath)
         })
 


### PR DESCRIPTION
Add `req.operation` to each incoming request so all middleware has access to Swagger context of the targeted operation.