### PR TITLE
Don't default boolean parameters to 'false', they can be undefined too.

### DIFF
--- a/src/routeParameters.js
+++ b/src/routeParameters.js
@@ -49,6 +49,8 @@ function parseBoolean(paramSchema, value) {
       case 'yes':
       case 'y':
         return true
+      case 'undefined':
+        return undefined
       default:
         return false
     }


### PR DESCRIPTION
Boolean parameters are defaulting to 'false' even when they are not set. This fix allows them to be undefined.