### PR TITLE
Update validation error message

### DIFF
--- a/src/apiSpecs.js
+++ b/src/apiSpecs.js
@@ -365,6 +365,12 @@ function validateBody(res, bodySchema, responseSpec) {
     // Instead we capture all errors and then throw the first one found
     const result = jsonSchema.validate(res.data, bodySchema, { throwError: false })
     if (result && result.errors.length) {
+      const details = result.errors
+        .slice(1)
+        .map( e => `\n\t - ${e.property} - ${e.message}`)
+        .join('')
+
+      result.errors[0].message += details
       throw result.errors[0]
     }
   }


### PR DESCRIPTION
Hi,

I add a small extension to the schema validation error handling

The original error handling hide the details of the error when the ` jsonSchema.validate` return with multiple errors, for example when multiple subschema validation fail.

A real word example:

Original error message (this case I know the data contains 2 errors, but I do not know the details):
```
     instance does not match allOf schema [subschema 1] with 2 error[s]:
```

New error message:

```
     instance does not match allOf schema [subschema 1] with 2 error[s]:
	 - instance.entries[2].list.itemTypes[1] - is not one of enum values: A,B,C
	 - instance.entries[2].list.items[6].type - is not one of enum values: A,B,C
```