### PR TITLE
Add security extension to support logical OR of token scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ It takes an array of scopes you decode from the authenticated request and verifi
 required scope(s) defined be the scheme are present. If they're not a `403 Forbidden` 
 [error](https://en.wikipedia.org/wiki/HTTP_403#Difference_from_status_.22401_Unauthorized.22) is returned.
 
-When multiple scopes are defined for a security definition, Swagger expects all of them to be present
-for `verifyScopes` to succeed. As an extension, swagger-routes also supports the logical OR of token
-scopes, so if *any* exist then `verifyScopes` succeeds.
+When multiple oauth scopes are defined for the security of an endpoint, Swagger expects all of them to be 
+present for a call to proceed. As an extension to this, `swagger-routes` also supports the logical OR of 
+token scopes, so if *any* exist then `verifyScopes` succeeds.
 
-This example will pass the auth check if either a `Catalog` OR `Playback` scope exist.
+As an example, this definition below will pass the auth check if either a `Catalog` OR `Playback` scope exist.
 
 ```yaml
   ...

--- a/README.md
+++ b/README.md
@@ -216,6 +216,23 @@ It takes an array of scopes you decode from the authenticated request and verifi
 required scope(s) defined be the scheme are present. If they're not a `403 Forbidden` 
 [error](https://en.wikipedia.org/wiki/HTTP_403#Difference_from_status_.22401_Unauthorized.22) is returned.
 
+When multiple scopes are defined for a security definition, Swagger expects all of them to be present
+for `verifyScopes` to succeed. As an extension, swagger-routes also supports the logical OR of token
+scopes, so if *any* exist then `verifyScopes` succeeds.
+
+This example will pass the auth check if either a `Catalog` OR `Playback` scope exist.
+
+```yaml
+  ...
+  security:
+    - accountAuth:
+      - Catalog
+      - Playback
+  x-security:
+    accountAuth:
+      OR_scopes: true
+```
+
 Remember if no credentials are supplied a `401 Unauthorized` should be returned.
 
 ##### Generating Authorizer Files

--- a/src/routeSecurity.js
+++ b/src/routeSecurity.js
@@ -48,7 +48,9 @@ function createAuthCheck(operation, authorizers) {
 
       return new Promise((resolve, reject) => {
         const authorizer = authorizers.get(id)
-        const ext = (securityExt && securityExt[id]) || {}
+        const ext = (securityExt && securityExt[id]) 
+          ? securityExt[id]
+          : {}
         
         if (typeof authorizer === 'function') {
           const requiredScopes = scheme[id]


### PR DESCRIPTION
When multiple oauth scopes are defined for the security of an endpoint, Swagger expects all of them to be present for a call to proceed. As an extension to this, `swagger-routes` also supports the logical OR of token scopes, so if *any* exist then `verifyScopes` succeeds.

As an example, this definition below will pass the auth check if either a `Catalog` OR `Playback` scope exist in the auth token.

```yaml
  ...
  security:
    - accountAuth:
      - Catalog
      - Playback
  x-security:
    accountAuth:
      OR_scopes: true
```