### PR TITLE
Add docs middleware option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ server.listen(8080)
 
 - `api`: path to your Swagger spec, or the loaded spec reference.
 - `docsPath`: url path to serve your swagger api json. Defaults to `/api-docs`.
+- `docsMiddleware`: An optional middleware function that can be used to secure the api docs endpoint.
 - `handlers`: directory where your handler files reside. Defaults to `./handlers`. Can alternatively be a function to return a handler function given an operation.
 - `authorizers`: directory where your authorizer files reside. Defaults to `./security`. Can alternatively be a function to return an authorizer middleware given a swagger security scheme.
 - `maintainHeaders`: Keeps your generated handler doc headers in sync with your Swagger api. Default is false.

--- a/src/options.js
+++ b/src/options.js
@@ -17,6 +17,7 @@ const DEFAULT_EXPRESS_OPTIONS = {
 
 const DEFAULT_OPTIONS = {
   docsPath: '/api-docs',
+  docsMiddleware: function docsMiddleware(req, res, next) { next() },
   handlers: {
     path: './handlers',
     template: path.join(__dirname, '..', 'template', 'handler.mustache'),

--- a/src/routeRegister.js
+++ b/src/routeRegister.js
@@ -33,5 +33,5 @@ function getHttpMethod(app, operation) {
 
 function registerDocsRoute(app, options) {
   const docsPath = path.normalize(`/${options.api.basePath}/${options.docsPath}`)
-  app.get(docsPath, function handler(req, res) { res.json(options.api) })
+  app.get(docsPath, options.docsMiddleware, function handler(req, res) { res.json(options.api) })
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,7 +42,7 @@ describe('index', () => {
           verifyAppStackSize(app, 2)
 
           verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ])
-          verifyRoute(app, options.docsPath, [ 'handler' ])
+          verifyRoute(app, options.docsPath, [ 'docsMiddleware', 'handler' ])
         })
 
         it('should always register doc route', () => {
@@ -53,7 +53,7 @@ describe('index', () => {
 
           verifyAppStackSize(app, 1)
 
-          verifyRoute(app, options.docsPath, [ 'handler' ])
+          verifyRoute(app, options.docsPath, [ 'docsMiddleware', 'handler' ])
         })
 
         it('should support handler middleware', () => {
@@ -144,10 +144,10 @@ describe('index', () => {
           verifyAppStackSize(app, 4)
 
           verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ], api.basePath)
-          verifyRoute(app, options.docsPath, [ 'handler' ], api.basePath)
+          verifyRoute(app, options.docsPath, [ 'docsMiddleware', 'handler' ], api.basePath)
 
           verifyRoute(app, '/pets', [ 'augmentReq', 'validator', 'handler' ], api2.basePath)
-          verifyRoute(app, options.docsPath, [ 'handler' ], api2.basePath)
+          verifyRoute(app, options.docsPath, [ 'docsMiddleware', 'handler' ], api2.basePath)
         })
 
         it('should expose swagger apis via app/server property', () => {


### PR DESCRIPTION
Currently the OpenAPI spec is available to all external parties looking at the service (default endpoint is `/api-docs`).

This addition adds a `docsMiddleware` option which can be used to restrict this endpoint as needed.