### PR TITLE
Catch case where restify replaces undefined path param with empty string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5"
+  - "8"
 script:
   - npm run lint
   - npm test

--- a/src/routeParameters.js
+++ b/src/routeParameters.js
@@ -94,8 +94,9 @@ function getPathParams(req, operation) {
   return operation.parameters
     .filter(op => op.in === 'path')
     .reduce((pathParams, op) => {
-      if (params[op.name] !== undefined) {
-        pathParams[op.name] = params[op.name]
+      const v = params[op.name]
+      if (v !== undefined && v !== '') {
+        pathParams[op.name] = v
       }
       return pathParams
     }, {})

--- a/test/routeValidation.spec.js
+++ b/test/routeValidation.spec.js
@@ -151,12 +151,12 @@ describe('routeValidation', () => {
     })
 
     it('should ignore allowEmptyValue in parameters outside of formData or query', () => {
-      const spec = newSpec(PARAM.INT, { allowEmptyValue: true, 'in': 'path' })
+      const spec = newSpec(PARAM.INT, { allowEmptyValue: true, required: true, 'in': 'path' })
       const req = newReq({ params: { 'INT': '' } })
       const failure = validateRequest(req, spec)
 
       expect(failure).toExist()
-      expect(failure.errors[0].message).toBe('path.INT is not of a type(s) integer')
+      expect(failure.errors[0].message).toBe('path requires property "INT"')
     })
 
     it('should restrict values to enum set', () => {
@@ -229,6 +229,16 @@ describe('routeValidation', () => {
 
       expect(failure).toExist()
       expect(failure.errors[0].message).toBe('path.STRING does not match pattern "^s"')
+    })
+
+    it('should fail if string path param is empty', () => {
+      const param = copy({ in: 'path', required: true }, PARAM.STRING)
+      const spec = newSpec(param)
+      const req = newReq({ params: { [param.name]: '' } })
+
+      const failure = validateRequest(req, spec)
+      expect(failure).toExist()
+      expect(failure.errors[0].message).toBe('path requires property "STRING"')
     })
 
     it('should restrict an array length to a defined maximum', () => {


### PR DESCRIPTION
Restify sees to replace undefined path params with an empty string, so for a request to `GET /resource/{id}` that looks like `GET /resource/`, path param of `id` would contain an empty string instead of being `undefined`. This is invalid in OpenAPI as path parameters must exist.

This patch captures that case to ensure validation fails the request.