### PR TITLE
Attempt to convert collectionFormat list items so that they validate correctly.

### DIFF
--- a/src/routeParameters.js
+++ b/src/routeParameters.js
@@ -44,7 +44,7 @@ function parseCollectionFormat(paramSchema, value) {
     // create a do-nothing converter
     let converter = (v) => { return v }
 
-    if (['integer', 'long', 'number'].includes(paramSchema.items.type)) {
+    if ([ 'integer', 'long', 'number' ].includes(paramSchema.items.type)) {
       converter = toNumber
     } else if (paramSchema.items.type === 'boolean') {
       converter = toBoolean
@@ -56,16 +56,16 @@ function parseCollectionFormat(paramSchema, value) {
 
 function toBoolean(value) {
   switch(`${value}`.toLowerCase().trim()) {
-  case 'true':
-  case '1':
-  case 'on':
-  case 'yes':
-  case 'y':
-    return true
-  case 'undefined':
-    return undefined
-  default:
-    return false
+    case 'true':
+    case '1':
+    case 'on':
+    case 'yes':
+    case 'y':
+      return true
+    case 'undefined':
+      return undefined
+    default:
+      return false
   }
 }
 

--- a/src/routeParameters.js
+++ b/src/routeParameters.js
@@ -35,33 +35,58 @@ function formatGroupData(groupSchema, groupData, groupId, req) {
 
 function parseCollectionFormat(paramSchema, value) {
   if (paramSchema.type === 'array' && typeof value === 'string') {
-    return stringValueToArray(value, paramSchema.collectionFormat || 'csv')
+    // convert the collection string into an array of items
+    let values = stringValueToArray(value, paramSchema.collectionFormat || 'csv')
+
+    // may need to convert it based on the schema to something
+    // else so that jsonschema will validate it correctly
+
+    // create a do-nothing converter
+    let converter = (v) => { return v }
+
+    if (['integer', 'long', 'number'].includes(paramSchema.items.type)) {
+      converter = toNumber
+    } else if (paramSchema.items.type === 'boolean') {
+      converter = toBoolean
+    }
+    return values.map((v) => converter(v))
+  }
+  return value
+}
+
+function toBoolean(value) {
+  switch(`${value}`.toLowerCase().trim()) {
+  case 'true':
+  case '1':
+  case 'on':
+  case 'yes':
+  case 'y':
+    return true
+  case 'undefined':
+    return undefined
+  default:
+    return false
+  }
+}
+
+function toNumber(value) {
+  const num = Number(value)
+  if (!isNaN(num)) {
+    return num
   }
   return value
 }
 
 function parseBoolean(paramSchema, value) {
   if (paramSchema.type === 'boolean') {
-    switch(`${value}`.toLowerCase().trim()) {
-      case 'true':
-      case '1':
-      case 'on':
-      case 'yes':
-      case 'y':
-        return true
-      case 'undefined':
-        return undefined
-      default:
-        return false
-    }
+    return toBoolean(value)
   }
   return value
 }
 
 function parseNumber(paramSchema, value) {
   if ((paramSchema.type === 'integer' || paramSchema.type === 'number') && value !== '') {
-    const num = Number(value)
-    if (!isNaN(num)) return num
+    return toNumber(value)
   }
   return value
 }


### PR DESCRIPTION
Convert collectionFormat lists to the specified type so that jsonschema validates correctly. For example, a parameter type such as this:

idcsv: {name: ids, description: 'list of IDs', in: query, type: array, items: {type: number, format: int32}, collectionFormat: csv, minItems: 1}

The existing code simply returns a list of strings, however, jsonschema won't validate correctly unless the items are first converted to integers.