### PR TITLE
Fix the creation of schema objects originated from allOf keyword

### DIFF
--- a/test/_fixture/petstore.yml
+++ b/test/_fixture/petstore.yml
@@ -72,6 +72,27 @@ paths:
           description: unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /feeds/{feedId}:
+    get:
+      summary: Info for a specific feed
+      operationId: showFeedById
+      tags:
+        - feeds
+      parameters:
+        - name: feedId
+          in: path
+          required: true
+          description: The id of the feed to retrieve
+          type: string
+      responses:
+        200:
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Feed'
+          default:
+            description: unexpected error
+            schema:
+              $ref: '#/definitions/Error'
 definitions:
   Pet:
     required:
@@ -89,6 +110,21 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/Pet'
+  Feed:
+    allOf:
+      - required:
+          - id
+          - brand
+        properties:
+          id:
+            type: integer
+            format: int64
+          brand:
+            type: string
+      - properties:
+          amount:
+            type: integer
+            format: int64
   Error:
     required:
       - code

--- a/test/swaggerSpec.spec.js
+++ b/test/swaggerSpec.spec.js
@@ -48,6 +48,29 @@ describe('swaggerSpec', () => {
       expect(bodySchema).toEqual(spec.definitions.Pet)
     })
 
+    it('should resolve parameter body schemas reference', () => {
+      spec.paths['/feeds/{feedId}'].put = {
+        operationId: 'updateFeed',
+        parameters: [ {
+          in: 'body',
+          schema: {
+            $ref: '#/definitions/Feed'
+          }
+        } ]
+      }
+      const operations = swaggerSpec.getAllOperations(spec)
+      const opt = operations.find(opt => opt.id === 'updateFeed')
+      const bodySchema = opt.paramGroupSchemas.body
+
+      expect(bodySchema).toEqual({
+        required: spec.definitions.Feed.allOf[0].required,
+        properties: Object.assign(
+          spec.definitions.Feed.allOf[0].properties,
+          spec.definitions.Feed.allOf[1].properties
+        )
+      })
+    })
+
     it('should resolve parameter array items reference', () => {
       spec.paths['/pets/{petId}'].get = {
         operationId: 'updatePet',


### PR DESCRIPTION
When creating the schema objects that will be validated on the request, schemas created using the "allOf" keyword are not being treated and an empty object is used in its place.
This PR handles this case, checking whether the schema is a simple schema (with the properties "required" and "properties") or a schema with the "allOf" keyword.